### PR TITLE
[FIX] fetch revision before creating worktree

### DIFF
--- a/odev/common/connectors/git.py
+++ b/odev/common/connectors/git.py
@@ -686,6 +686,7 @@ class GitConnector(Connector):
             self.worktrees_path.mkdir(parents=True, exist_ok=True)
 
             try:
+                self.repository.git.fetch("origin", revision)
                 self.repository.git.worktree("add", path, revision, "--force")
             except GitCommandError as error:
                 if "fatal: invalid reference" in error.stderr:


### PR DESCRIPTION
## Description

Odoo 18.0 just released and it is not possible to create the worktree in that version if odev was installed before the 18.0 brnach creation.
