### PR TITLE
[IMP] run: background-load second database from template while run

### DIFF
--- a/odev/commands/database/run.py
+++ b/odev/commands/database/run.py
@@ -1,12 +1,75 @@
 """Run an Odoo database locally."""
 
+import multiprocessing
+import time
 
 from odev.common import args, progress
 from odev.common.commands import OdoobinTemplateCommand
+from odev.common.databases import LocalDatabase
 from odev.common.logging import logging
 
 
 logger = logging.getLogger(__name__)
+
+
+class DatabaseTemplateSwapHandler(
+    multiprocessing.Process
+):  # TODO: check is possible/better with thread, got errors with signal when trying so
+    """Handle the swapping of the template database for a running Odoo instance."""
+
+    name = "template_pool_handler"
+    daemon = True
+
+    WAIT_TIMEOUT = 60 * 60  # 1 hour
+    WAIT_DELAY = 10
+    """Time to wait before checking if the template pool is restored."""
+
+    def __init__(self, tempate_name, database_name, odev):
+        super().__init__()
+        self.tempate_name = tempate_name
+        self.database_name = database_name
+        self.odev = odev
+
+        self._pool_size = 2
+        self._pool_index = 0
+        self._pool_db_is_restored = tuple(multiprocessing.Event() for _ in range(self._pool_size))
+
+    def compute_database_name(self, pool_index=None):
+        """Compute the database name based on the template name and the pool index."""
+        if pool_index is None:
+            pool_index = self._pool_index
+        if pool_index == 0:
+            return self.database_name
+        else:
+            return f"{self.database_name}-swap{pool_index}"
+
+    def wait_database_ready(self):
+        """Wait for the database to be ready."""
+        event_to_wait = self._pool_db_is_restored[self._pool_index]
+        if not event_to_wait.is_set():
+            logger.info(f"Waiting for database {self.compute_database_name(self._pool_index)!r} to be ready")
+        # Wait for the database to be ready before starting the Odoo instance
+        self._pool_db_is_restored[self._pool_index].wait(self.WAIT_TIMEOUT)
+        # Mark the previous database as not ready (will need to be restored again)
+        self._pool_db_is_restored[(self._pool_index - 1) % self._pool_size].clear()
+        # Increase the pool index so that next call will use the next database
+        current_pool_index = self._pool_index  # store current pool index for name computation
+        self._pool_index = (self._pool_index + 1) % self._pool_size  # next pool index
+        return self.compute_database_name(current_pool_index)
+
+    def run(self):
+        # TODO: currently we are in a process so be careful that we shouldn't use attributes like self._pool_index
+        #  as the memory is NOT shared (so it's value will stay at 0)
+        while True:
+            for i in range(self._pool_size):
+                if self._pool_db_is_restored[i].is_set():
+                    continue
+                db_name = self.compute_database_name(i)
+                logger.info(f"Background restoring template {self.tempate_name!r} in database {db_name!r}")
+                self.odev.run_command("create", "--force", "--from-template", self.tempate_name, db_name)
+                self._pool_db_is_restored[i].set()
+                time.sleep(self.WAIT_DELAY)
+            time.sleep(self.WAIT_DELAY)
 
 
 class RunCommand(OdoobinTemplateCommand):
@@ -23,6 +86,14 @@ class RunCommand(OdoobinTemplateCommand):
         description="""Name of an existing PostgreSQL database to copy before running.
         If passed without a value, search for a template database with the same name as the new database.
         """
+    )
+    reload_template = args.Flag(
+        aliases=["--reload-template", "-R"],
+        description="""A few seconds after the database started,
+        restore a second database with a different name from the same database template in background.
+        When the first database is stopped, the second one will be used directly.
+        To exit the command, use Ctrl+C (possibly multiple times).
+        """,
     )
 
     def __init__(self, *args, **kwargs) -> None:
@@ -45,6 +116,24 @@ class RunCommand(OdoobinTemplateCommand):
                 with progress.spinner(f"Reset database {self._database.name!r} from template {self._template.name!r}"):
                     self._database.drop()
 
-            self.odev.run_command("create", "--from-template", self._template.name, self._database.name)
+            if self.reload_template:
+                self.template_pool_handler = DatabaseTemplateSwapHandler(
+                    self._template.name, self._database.name, self.odev
+                )
+                self.template_pool_handler.start()
+                self.template_pool_handler.wait_database_ready()
+            else:
+                self.odev.run_command("create", "--from-template", self._template.name, self._database.name)
 
         self.odoobin.run(args=self.args.odoo_args, progress=self.odoobin_progress)
+
+        while self.reload_template:
+            self._database = LocalDatabase(self.template_pool_handler.wait_database_ready())
+            logger.debug(f"Reloading with database {self._database.name!r}")
+            self.odoobin.run(args=self.args.odoo_args, progress=self.odoobin_progress)
+
+    def cleanup(self):
+        if hasattr(self, "template_pool_handler"):
+            self.template_pool_handler.terminate()
+            self.template_pool_handler.join()
+        super().cleanup()


### PR DESCRIPTION
## Description

Before this commit:
Restoring a database template can be a long process depending on the database size. In upgrade/maintenance, it can be needed that we re-run the same database multiple times to test upgrade scripts. As such, we generally interupt the running odoo-bin process then launch again the commdand:
`odev run <db> -t <db template>`

After this commit:
The idea is to use the time while we are testing on the running database to restore another database of the same template then "swap" them when the first one is interupted in order to be available to run as soon as possible.
This process goes on as long as odev itself is interupted with Ctrl+C

## Compliance

- [ ] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [ ] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [ ] I have added or modified unit tests where necessary
- [ ] I have added new libraries to the `requirements.txt` file, if any
- [ ] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
