### PR TITLE
[FIX] run: enable on the fly db creation from template

### DIFF
--- a/odev/commands/database/create.py
+++ b/odev/commands/database/create.py
@@ -44,8 +44,6 @@ class CreateCommand(OdoobinTemplateCommand):
         """,
     )
 
-    _database_exists_required = False
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -58,6 +56,11 @@ class CreateCommand(OdoobinTemplateCommand):
             self._database = LocalDatabase(self.args.database)
 
         self.infer_template_instance()
+
+    @property
+    def _database_exists_required(self) -> bool:
+        """Return True if a database has to exist for the command to work."""
+        return False
 
     @property
     def version(self) -> OdooVersion:

--- a/odev/commands/database/delete.py
+++ b/odev/commands/database/delete.py
@@ -41,8 +41,12 @@ class DeleteCommand(ListLocalDatabasesMixin, LocalDatabaseCommand):
     )
 
     _database_arg_required = False
-    _database_exists_required = False
     _exclusive_arguments = [("database", "expression")]
+
+    @property
+    def _database_exists_required(self) -> bool:
+        """Return True if a database has to exist for the command to work."""
+        return False
 
     def run(self):
         if self._database.exists:

--- a/odev/commands/database/quickstart.py
+++ b/odev/commands/database/quickstart.py
@@ -38,7 +38,11 @@ class QuickStartCommand(DatabaseCommand):
     )
 
     _database_allowed_platforms = []
-    _database_exists_required = False
+
+    @property
+    def _database_exists_required(self) -> bool:
+        """Return True if a database has to exist for the command to work."""
+        return False
 
     def run(self):
         passthrough_args = ["--branch", self.args.branch] if self.args.branch else []

--- a/odev/commands/database/restore.py
+++ b/odev/commands/database/restore.py
@@ -26,8 +26,12 @@ class RestoreCommand(DatabaseCommand):
         """,
     )
 
-    _database_exists_required = False
     _database_allowed_platforms = ["local"]
+
+    @property
+    def _database_exists_required(self) -> bool:
+        """Return True if a database has to exist for the command to work."""
+        return False
 
     def run(self):
         self.check_database()

--- a/odev/commands/database/run.py
+++ b/odev/commands/database/run.py
@@ -29,14 +29,13 @@ class RunCommand(OdoobinTemplateCommand):
         super().__init__(*args, **kwargs)
         self.infer_template_instance()
 
+    @property
+    def _database_exists_required(self) -> bool:
+        """Return True if a database has to exist for the command to work."""
+        return not bool(self.from_template)
+
     def run(self):
         """Run the odoo-bin process for the selected database locally."""
-        if not self.odoobin:
-            raise self.error(f"Could not spawn process for database {self._database.name!r}")
-
-        if self.odoobin.is_running:
-            raise self.error(f"Database {self._database.name!r} is already running")
-
         if self._template:
             if not self._template.exists:
                 raise self.error(f"Template database {self._template.name!r} does not exist")
@@ -46,5 +45,11 @@ class RunCommand(OdoobinTemplateCommand):
                     self._database.drop()
 
             self.odev.run_command("create", "--from-template", self._template.name, self._database.name)
+
+        if not self.odoobin:
+            raise self.error(f"Could not spawn process for database {self._database.name!r}")
+
+        if self.odoobin.is_running:
+            raise self.error(f"Database {self._database.name!r} is already running")
 
         self.odoobin.run(args=self.args.odoo_args, progress=self.odoobin_progress)

--- a/odev/common/commands/database.py
+++ b/odev/common/commands/database.py
@@ -36,9 +36,6 @@ class DatabaseCommand(Command, ABC):
     _database_arg_required: ClassVar[bool] = True
     """Whether the command requires a database to be specified or not in its arguments."""
 
-    _database_exists_required: ClassVar[bool] = True
-    """Whether the database must exist before running the command."""
-
     _database_platforms: ClassVar[Mapping[str, type[DatabaseType]]] = {
         "local": LocalDatabase,
         "remote": RemoteDatabase,
@@ -94,6 +91,11 @@ class DatabaseCommand(Command, ABC):
                 raise self.error("No database specified")
             if not self._database.exists:
                 raise self.error(f"Database {self._database.name!r} does not exist")
+
+    @property
+    def _database_exists_required(self) -> bool:
+        """Return True if a database has to exist for the command to work."""
+        return True
 
     @classmethod
     def prepare_command(cls, *args, **kwargs) -> None:
@@ -190,9 +192,13 @@ class DatabaseOrRepositoryCommand(DatabaseCommand, ABC):
     """
 
     _database_arg_required = False
-    _database_exists_required = False
 
     repository = args.String(description="GitHub URL or name of a repository.", nargs="?")
+
+    @property
+    def _database_exists_required(self) -> bool:
+        """Return True if a database has to exist for the command to work."""
+        return False
 
     def infer_database_instance(self) -> DatabaseType:
         if any(char in self.args.database for char in "@:/"):


### PR DESCRIPTION
https://github.com/odoo-odev/odev/issues/50

## Description

enable creation of a database on the fly when running `odev run` with -t and the database does not exist

also modify _database_exists_required to make it a property instead of a class variable, so it can be used in run to differentiate from instances with and without template

## Linked Issues

Link the issues that this PR solves, if any:

- #50 
- ...

## Compliance

- [x] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [ ] I have added or modified unit tests where necessary
- [ ] I have added new libraries to the `requirements.txt` file, if any
- [x] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
