### PR TITLE
[IMP] Improve secrets (de)cyphering by saving encryption key fingerprint

### DIFF
--- a/odev/common/config.py
+++ b/odev/common/config.py
@@ -194,6 +194,19 @@ class RepositoriesSection(Section):
         self.set("date", value.strftime(DATETIME_FORMAT) if isinstance(value, datetime) else value)
 
 
+class SecuritySection(Section):
+    """Security configuration."""
+
+    @property
+    def encryption_key(self) -> str:
+        """Encryption key."""
+        return cast(str, self.get("encryption_key", ""))
+
+    @encryption_key.setter
+    def encryption_key(self, value: str):
+        self.set("encryption_key", value)
+
+
 class Config:
     """Odev configuration.
     Light wrapper around configparser to write and retrieve configuration values saved on disk.
@@ -216,6 +229,9 @@ class Config:
 
     repositories: RepositoriesSection
     """Configuration for Odoo repositories."""
+
+    security: SecuritySection
+    """Configuration for security and secrets encryption."""
 
     def __init__(self, name: str = "odev"):
         self.name: str = name


### PR DESCRIPTION
Avoid looping unnecessaryly through all available keys when decrypting or encrypting a secret. Instead, use the fingerprint saved in the config if available.

## Compliance

- [x] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [x] I have added or modified unit tests where necessary
- [x] I have added new libraries to the `requirements.txt` file, if any
- [x] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
