### PR TITLE
[FIX] Use Repository instead of GitConnector

### DIFF
--- a/odev/commands/git/clone.py
+++ b/odev/commands/git/clone.py
@@ -32,7 +32,7 @@ class CloneCommand(DatabaseOrRepositoryCommand):
 
     def _clone_repository(self):
         """Find and clone the correct repository."""
-        git = GitConnector(self.args.repository or self._database.repository.name)
+        git = GitConnector(self.args.repository or self._database.repository.full_name)
 
         if git.path.exists():
             logger.info(f"Repository {git.name!r} already cloned under {git.path.as_posix()}")


### PR DESCRIPTION
## Description

Needed by https://github.com/odoo-ps/odev-plugin-hosted/pull/9

Using full_name as the repository is now always a Repository class

## Compliance

- [x] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [x] I have added or modified unit tests where necessary
- [x] I have added new libraries to the `requirements.txt` file, if any
- [x] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
