### PR TITLE
[IMP] various: centralize per-version pull interval logic

### DIFF
--- a/odev/commands/git/pull.py
+++ b/odev/commands/git/pull.py
@@ -16,20 +16,6 @@ class PullCommand(FetchCommand):
     _name = "pull"
     _help = "Pull changes in local worktrees managed by odev."
 
-    def run(self):
-        if not self.args.bypass_prompt:
-            if self.args.version:
-                if not self.odev.config.repositories.is_pull_needed(self.args.version):
-                    next_pull = self.odev.config.repositories.next_pull_date(self.args.version)
-                    days = (next_pull - datetime.today()).days + 1
-                    logger.info(f"Skipping pull for {self.args.version!r}, next pull scheduled in {days} days")
-                    return
-            elif all(not self.odev.config.repositories.is_pull_needed(name) for name in self.grouped_worktrees):
-                logger.info("All worktrees are recently pulled, skipping pull. Use --force to pull anyway.")
-                return
-
-        super().run()
-
     def run_hook(self, name: str, changes: list[tuple[str, int, int]]):
         """Print a summary of the pending changes for a worktree."""
         for change in changes:

--- a/odev/commands/git/pull.py
+++ b/odev/commands/git/pull.py
@@ -1,5 +1,7 @@
 """Pull changes in local worktrees."""
 
+from datetime import datetime
+
 from odev.commands.git.fetch import FetchCommand
 from odev.common import progress
 from odev.common.logging import logging
@@ -12,6 +14,21 @@ class PullCommand(FetchCommand):
     """Pull changes in local worktrees managed by odev."""
 
     _name = "pull"
+    _help = "Pull changes in local worktrees managed by odev."
+
+    def run(self):
+        if not self.args.bypass_prompt:
+            if self.args.version:
+                if not self.odev.config.repositories.is_pull_needed(self.args.version):
+                    next_pull = self.odev.config.repositories.next_pull_date(self.args.version)
+                    days = (next_pull - datetime.today()).days + 1
+                    logger.info(f"Skipping pull for {self.args.version!r}, next pull scheduled in {days} days")
+                    return
+            elif all(not self.odev.config.repositories.is_pull_needed(name) for name in self.grouped_worktrees):
+                logger.info("All worktrees are recently pulled, skipping pull. Use --force to pull anyway.")
+                return
+
+        super().run()
 
     def run_hook(self, name: str, changes: list[tuple[str, int, int]]):
         """Print a summary of the pending changes for a worktree."""
@@ -44,3 +61,5 @@ class PullCommand(FetchCommand):
             ):
                 worktree.connector.pull_worktrees([worktree], force=True)
                 logger.info(f"Pulled {behind} commits in {worktree.connector.name!r} for version {worktree.branch!r}")
+
+        self.odev.config.repositories.set_date(name, datetime.today())

--- a/odev/common/config.py
+++ b/odev/common/config.py
@@ -3,7 +3,7 @@ import inspect
 import sys
 from collections.abc import Iterable
 from configparser import ConfigParser
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import (
     Literal,
@@ -214,6 +214,31 @@ class RepositoriesSection(Section):
     @date.setter
     def date(self, value: str | datetime):
         self.set("date", value.strftime(DATETIME_FORMAT) if isinstance(value, datetime) else value)
+
+    def get_date(self, version: str) -> datetime:
+        """Last time a specific version was pulled from GitHub."""
+        value = self.get(f"date_{version}")
+        if not value:
+            return self.date
+        return datetime.strptime(value, DATETIME_FORMAT)
+
+    def set_date(self, version: str, value: datetime):
+        """Set the last time a specific version was pulled from GitHub."""
+        self.set(f"date_{version}", value.strftime(DATETIME_FORMAT))
+        self.date = value
+
+    def is_pull_needed(self, version: str | None) -> bool:
+        """Check whether a pull is needed for the given version."""
+        if not version:
+            return True
+
+        return datetime.today() >= self.next_pull_date(version)
+
+    def next_pull_date(self, version: str) -> datetime:
+        """Get the next scheduled pull date for the given version."""
+        pull_date = self.get_date(version)
+        next_monday = pull_date + timedelta(days=(7 - pull_date.weekday()))
+        return next_monday.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 class SecuritySection(Section):

--- a/odev/common/config.py
+++ b/odev/common/config.py
@@ -234,11 +234,22 @@ class RepositoriesSection(Section):
 
         return datetime.today() >= self.next_pull_date(version)
 
+    @property
+    def interval(self) -> int:
+        """Interval between repository pull checks in days.\n        Pulls will be performed once every `interval` day(s).\n        Defaults to 7 days.\n"""
+        return int(cast(str, self.get("interval", "7")))
+
+    @interval.setter
+    def interval(self, value: str | int):
+        if not str(value).isdigit() or int(value) < 0:
+            raise ValueError(f"'repositories.interval' must be a positive integer, got {value!r}")
+
+        self.set("interval", str(value))
+
     def next_pull_date(self, version: str) -> datetime:
         """Get the next scheduled pull date for the given version."""
         pull_date = self.get_date(version)
-        next_monday = pull_date + timedelta(days=(7 - pull_date.weekday()))
-        return next_monday.replace(hour=0, minute=0, second=0, microsecond=0)
+        return (pull_date + timedelta(days=self.interval)).replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 class SecuritySection(Section):

--- a/odev/common/config.py
+++ b/odev/common/config.py
@@ -249,7 +249,19 @@ class RepositoriesSection(Section):
     def next_pull_date(self, version: str) -> datetime:
         """Get the next scheduled pull date for the given version."""
         pull_date = self.get_date(version)
-        return (pull_date + timedelta(days=self.interval)).replace(hour=0, minute=0, second=0, microsecond=0)
+        # Start of the week (Monday 00:00) of the last pull
+        start_of_week = (pull_date - timedelta(days=pull_date.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        # Target date based on the interval
+        next_pull = start_of_week + timedelta(days=self.interval)
+
+        # If the interval is short or we've already passed the target day this week,
+        # ensure the next pull is scheduled for the next period.
+        if next_pull <= pull_date:
+            return (pull_date + timedelta(days=self.interval)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+        return next_pull
 
 
 class SecuritySection(Section):

--- a/odev/common/odoobin.py
+++ b/odev/common/odoobin.py
@@ -5,7 +5,7 @@ import shlex
 from ast import literal_eval
 from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import nullcontext
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
 from typing import (
@@ -711,14 +711,10 @@ class OdoobinProcess(OdevFrameworkMixin):
                 repository.create_worktree(f"{self.worktree}/{repository.path.name}", str(self.version or "master"))
 
         # Pull changes once per week, on Monday (or a later day if odev was not run)
-        pull_date = self.odev.config.repositories.date
-        next_monday = pull_date + timedelta(days=(7 - pull_date.weekday()))
-        next_monday = next_monday.replace(hour=0, minute=0, second=0, microsecond=0)
-        today = datetime.today()
-
-        if next_monday > today:
+        if not self.odev.config.repositories.is_pull_needed(self.version):
+            next_monday = self.odev.config.repositories.next_pull_date(self.version)
             return logger.debug(
-                f"Skipping worktree update, next pull scheduled in {(next_monday - today).days + 1} days"
+                f"Skipping worktree update, next pull scheduled in {(next_monday - datetime.today()).days + 1} days"
             )
 
         outdated_worktrees = list(self.outdated_odoo_worktrees())
@@ -750,7 +746,7 @@ class OdoobinProcess(OdevFrameworkMixin):
             for worktree in worktrees_to_pull:
                 worktree.connector.pull_worktrees(worktrees_to_pull, force=True)
 
-        self.odev.config.repositories.date = today
+        self.odev.config.repositories.set_date(self.version, datetime.today())
         return None
 
     def clone_repositories(self):

--- a/odev/setup/odoo.py
+++ b/odev/setup/odoo.py
@@ -98,4 +98,14 @@ def setup(odev: Odev) -> None:  # noqa: PLR0912
         else:
             logger.debug(f"Path {old_repo_path} does not exist, skipping")
 
-    return logger.info(f"Moved {len(repositories)} repositories to {new_parent_path}")
+    logger.info(f"Moved {len(repositories)} repositories to {new_parent_path}")
+
+    pull_interval = console.integer(
+        "How often should odev automatically pull changes for Odoo repositories (in days)?",
+        default=odev.config.repositories.interval,
+        min_value=0,
+    )
+    if pull_interval is not None:
+        odev.config.repositories.interval = pull_interval
+
+    return None


### PR DESCRIPTION
This PR introduces per-version tracking for repository pull dates to avoid redundant daily network requests. 

- Add get_date/set_date and interval logic to RepositoriesSection.
- Update PullCommand to verify timestamps before execution.
- Refactor OdoobinProcess to use version-specific pull schedules.

This ensures that odev pulls each Odoo version at most once per week (resetting on Mondays) unless forced.