### PR TITLE
[FIX] odoobin: fix AttributeError when addons is a list

### DIFF
--- a/odev/common/commands/odoobin.py
+++ b/odev/common/commands/odoobin.py
@@ -176,8 +176,8 @@ class OdoobinCommand(LocalDatabaseCommand, ABC):
     def combined_odoo_args(self) -> list[str]:
         """Aggregate odoo_args and any Odoo option that might have been captured by the positional 'addons' argument."""
         args = list(self.args.odoo_args)
-        if self.args.addons and self.args.addons.startswith("-"):
-            args.insert(0, self.args.addons)
+        if self.args.addons and self.args.addons[0].startswith("-"):
+            args.insert(0, ",".join(self.args.addons))
         return args
 
     def odoobin_progress(self, line: str):


### PR DESCRIPTION
The addons argument is defined as a List, but combined_odoo_args was calling startswith() directly on the list object instead of its elements. Ensure we check the first element and join them back to a string when needed to reconstruct the original Odoo option.