### PR TITLE
[FIX] common: kill the entire process group when using ctrl+c

### DIFF
--- a/odev/common/bash.py
+++ b/odev/common/bash.py
@@ -5,6 +5,7 @@ the subsystem.
 import os
 import pty
 import select
+import signal
 import sys
 import termios
 import tty
@@ -236,7 +237,8 @@ def stream(
                 char = os.read(sys.stdin.fileno(), 1)
 
                 if char == CTRL_C:
-                    process.terminate()
+                    # Kill the entire process group
+                    os.killpg(process.pid, signal.SIGTERM)
 
                 if char in (CTRL_C, CTRL_D):
                     os.write(master, char)


### PR DESCRIPTION
## Description

using ctrl+c during an "odoo run" doesn't fully terminate the python process

## Compliance

- [ ] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [ ] I have added or modified unit tests where necessary
- [x] I have added new libraries to the `requirements.txt` file, if any
- [ ] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
