### PR TITLE
[IMP] docs: migrate command reference to wiki and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,16 @@
 
 Automate common tasks relative to working with Odoo development databases.
 
-<!-- TOC depthFrom:2 -->
-
--   [ODEV](#odev)
-    -   [About](#about)
-    -   [Requirements](#requirements)
-    -   [Installation](#installation)
-    -   [Contributing](#contributing)
-    -   [Features](#features)
-        -   [Commands](#commands)
-        -   [Plugins](#plugins)
-            -   [Known Plugins](#known-plugins)
-        -   [Credentials](#credentials)
-
-<!-- /TOC -->
-
 ## About
 
 Odev is a multi-purpose tool designed for making the life of Odoo developers and support analysts easier.
 
 It provides wrapper scripts around common tasks, speeding up the whole process of working with databases and allowing
 shortcuts to otherwise lengthy commands.
+
+## Documentation
+
+Full documentation for all commands and features is available in the [Odev Wiki](https://github.com/odoo-odev/odev/wiki).
 
 ## Requirements
 
@@ -72,123 +61,3 @@ You have ideas to share but you don't want to dive in `odev`'s source code? No w
 feature.
 
 Check the [Contribution Guide](./docs/CONTRIBUTING.md) for more details about the contribution process.
-
-## Features
-
-### Commands
-
-Odev works with subcommands, each having specific effects.
-
-**Usage:** `odev <command> <args>`
-
-Arguments in square brackets (`[arg]`) are optional and can be omitted, arguments in curvy brackets (`{arg}`) are
-options to choose from, arguments without brackets (`arg`) are required.
-
-To see the list of all commands run `odev help`.
-
-To get help on a specific command and its usage, use `odev help <command>`.
-
-### Plugins
-
-Odev can be extended with plugins that are loaded from external GitHub repositories, they could be public or private to
-your organizations and allow to add new features and commands or modify existing ones.
-
-Plugins can be enabled with the predefined command `odev plugin --enable <plugin>`.
-
-#### Known Plugins
-
-[plugin-ai-translation]: https://github.com/odoo-odev/odev-plugin-ai-translation
-[plugin-ai-scaffold]: https://github.com/odoo-ps/odev-plugin-ai-scaffold
-[plugin-editor-vscode]: https://github.com/odoo-odev/odev-plugin-editor-vscode
-[plugin-export]: https://github.com/odoo-odev/odev-plugin-export
-[plugin-project]: https://github.com/odoo-odev/odev-plugin-project
-[plugin-hosted]: https://github.com/odoo-ps/odev-plugin-hosted
-
-| Name                                                          | Description                                                                                                  |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| [odoo-odev/odev-plugin-ai-translation][plugin-ai-translation] | Generate Odoo module translations using AI.                                                                  |
-| [odoo-odev/odev-plugin-ai-scaffold][plugin-ai-scaffold]       | Scaffold Odoo modules using AI, based on a formatted technical specification.                                |
-| [odoo-odev/odev-plugin-editor-vscode][plugin-editor-vscode]   | Interact with VSCode, open a debugger session and configure workspaces.                                      |
-| [odoo-odev/odev-plugin-export][plugin-export]                 | Export customizations from a database and convert Studio to code.                                            |
-| [odoo-odev/odev-plugin-project][plugin-project]               | Follow-up on projects and setup working directories for creating new Odoo modules.                           |
-| [odoo-ps/odev-plugin-hosted][plugin-hosted]                   | Interact with PaaS (odoo.sh) and SaaS (Odoo Online) databases, requires Odoo Technical Support access level. |
-
-### Credentials
-
-To avoid inputting the credentials every time `odev` is run, symmetric encryption is used to store them. This is done
-"automagically" with the help of an [`ssh-agent`](https://esc.sh/blog/ssh-agent-windows10-wsl2/)-loaded key. This means
-that `ssh-agent` needs to be available in the shell environment the command is being run from, otherwise a warning will
-be logged and credentials will need to be inputted every time. If you don't already have a custom script to launch
-`ssh-agent`, we recommend using `keychain`, that's an easy option to do that and manage the different keys available
-through `ssh-agent`.
-
-After installing `keychain`, and depending on the shell of your choice, the following lines need to be added to the
-`.bashrc`/`.zshrc`:
-
-```sh
-/usr/bin/keychain -q --nogui $HOME/.ssh/id_rsa
-source $HOME/.keychain/$HOST-sh
-```
-
-**Alternatively**, you can save the following script into a new file under `~/.profile.d/start_ssh_agent` and make it
-run automatically at startup by adding the line `source ~/.profile.d/start_ssh_agent` to your `~/.bashrc` or `~/.zshrc`
-file.
-
-```sh
-#!/bin/sh
-
-# ==============================================================================
-# This script loads declared SSH keys into the running ssh-agent, launching it
-# if necessary. This should ideally be sourced in the user's shell profile.
-# ==============================================================================
-
-env=~/.ssh/agent.env
-
-# --- Declare the path to the keys to add to the agent -------------------------
-declare -a keys=(
-  "$HOME/.ssh/id_ed25519" # <-- Edit this line to load your own SSH key(s)
-)
-
-# --- Common methods and shortcuts ---------------------------------------------
-
-agent_load_env() {
-  test -f "$env" && . "$env" >| /dev/null
-}
-
-agent_start() {
-  (umask 077; ssh-agent >| "$env")
-  . "$env" >| /dev/null 2>&1
-}
-
-agent_add_key() {
-  ssh-add $key >| /dev/null 2>&1
-}
-
-agent_add_keys() {
-  for i in "${keys[@]}"; do
-    ssh-add "$i" >| /dev/null 2>&1
-  done
-}
-
-# --- Load the agent -----------------------------------------------------------
-
-agent_load_env
-
-# agent_run_state:
-#   0: agent running with key
-#   1: agent running without key
-#   2: agent not running
-agent_run_state=$(ssh-add -l >| /dev/null 2>&1; echo $?)
-
-# --- Load the keys to the agent -----------------------------------------------
-
-if [ ! "$SSH_AUTH_SOCK" ] || [ $agent_run_state = 2 ]; then
-  agent_start
-  agent_add_keys
-elif [ "$SSH_AUTH_SOCK" ] && [ $agent_run_state = 1 ]; then
-  agent_add_keys
-fi
-
-unset env
-
-```


### PR DESCRIPTION
This PR refactors the project's documentation strategy by migrating the detailed command reference to the repository's Wiki.

**Changes:**
- **Wiki Migration**: All 31 command reference files and demonstration GIFs have been moved to the `odev.wiki` repository.
- **Simplified README**: The main repository README has been reduced to a concise overview, preserving the original wording for About, Requirements, Installation, and Contributing sections while pointing to the Wiki for usage details.
- **Clean History**: All logic changes and temporary tools have been removed from this PR to keep it strictly focused on documentation.