### PR TITLE
[FIX] common: improve python requirements parsing and caching

### DIFF
--- a/odev/common/python.py
+++ b/odev/common/python.py
@@ -32,7 +32,7 @@ RE_PACKAGE = re.compile(
         (?P<name>[\w_-]+)
         (?:
             (?P<op>[~<>=]+)
-            (?P<version>[\d.*]+)
+            (?P<version>[a-zA-Z\d.*+!_-]+)
         )?
         (?:
             \s*;\s*
@@ -85,6 +85,9 @@ class PythonEnv:
 
     pip_freeze_cache: ClassVar[TTLCache] = TTLCache(ttl=60)
     """Cache for pip freeze output."""
+
+    installed_packages_cache: ClassVar[TTLCache] = TTLCache(ttl=60)
+    """Cache for parsed installed packages."""
 
     def __init__(self, path: Path | str | None = None, version: str | None = None):
         """Initialize a python environment.
@@ -381,8 +384,8 @@ class PythonEnv:
             # Consider:
             #   - Package name:   odoo_upgrade
             #   - Version:        aaa1f0fee6870075e25cb5e6744e4c589bb32b46
-            package_name, package_version = package.split(" @ ") if " @ " in package else (package, package)
-            package_version = package_name.split("@")[-1] if "@" in package_name else "1.0.0"
+            package_name, package_url = package.split(" @ ") if " @ " in package else (package, package)
+            package_version = package_url.split("@")[-1] if "@" in package_url else "1.0.0"
         else:
             raise ValueError(f"Invalid package specification {package!r}")
 
@@ -394,6 +397,9 @@ class PythonEnv:
         :return: The result of the pip command execution.
         :rtype: CompletedProcess
         """
+        if (installed := self.installed_packages_cache.get(self.path.as_posix())) is not None:
+            return installed
+
         freeze = self.__pip_freeze_all()
         packages = freeze.stdout.decode().splitlines()
         installed: MutableMapping[str, Version | str] = {}
@@ -408,6 +414,7 @@ class PythonEnv:
 
             installed[package_name.strip().lower()] = package_version
 
+        self.installed_packages_cache.set(self.path.as_posix(), installed)
         return installed
 
     def missing_requirements(self, path: Path | str, raise_if_error: bool = True) -> Generator[str, None, None]:  # noqa: PLR0912
@@ -437,6 +444,11 @@ class PythonEnv:
                 continue
 
             if "git+" in line:
+                if " @ " not in line:
+                    logger.warning(
+                        f"Git requirement {line!r} is not named. "
+                        "Please use the format 'package_name @ git+url@version' to avoid issues."
+                    )
                 package_name, package_version = self.__package_spec(line)
                 installed_version = installed_packages.get(package_name)
 


### PR DESCRIPTION
### Problem
1.  **Git Parsing Bug**: When a git requirement is specified with the recommended format `package_name @ git+url@version`, `odev` would incorrectly extract the version from the package name instead of the URL, leading to constant re-installations because it thought the version was incorrect (e.g., `1.0.0 != master`).
2.  **Version String Limitation**: The `RE_PACKAGE` regex was too restrictive, only allowing digits and dots. It failed to parse versions like `5.4.2.post1`, causing it to ignore the environment markers (conditions) that follow. This led to incorrect version mismatches (e.g., trying to apply a Python < 3.11 requirement on Python 3.12).
3.  **Redundant Logging**: `installed_packages()` was called for every requirements file check, causing redundant parsing and logging of "Invalid version format" for git-based packages at the DEBUG level.
4.  **Best Practice Enforcement**: Unnamed git requirements (just the URL) make it hard for tools to correlate installed packages.

### Proposed Changes
- **Fixed `__package_spec`**: Now correctly identifies the source of the version string in git-based requirements.
- **Improved `RE_PACKAGE`**: Expanded the allowed characters in version strings to support PEP 440 suffixes (`post`, `rc`, `dev`, etc.).
- **Added Caching**: The parsed result of `installed_packages()` is now cached (TTL 60s), significantly reducing log noise and processing time when multiple requirements files are checked.
- **Added Warning**: A warning is now displayed if a `git+` requirement is not named, encouraging the use of the `pkg @ git+url` format.

### Examples

#### Fixed Git Requirement Parsing
Before, this would trigger an install every time:
```text
odoo_upgrade @ git+https://github.com/odoo/upgrade-util@master
```
**Log before**: `Incorrect git python package version 'odoo_upgrade' ('ae2fe6...' != '1.0.0')`
**Log after**: (Package correctly identified as up-to-date).

#### Fixed Complex Versions (`.post1`)
```text
cbor2==5.4.2.post1 ; python_version < '3.11'
```
**Before**: Regex stopped at `5.4.2`, ignored the condition, and saw a conflict with the installed version on Python 3.12.
**After**: Version `5.4.2.post1` is fully captured, and the condition is correctly evaluated.

---

### Verification
- Tested with a reproduction script covering all problematic cases.
- Existing `TestPythonEnv` tests pass.
- Verified that logs are much cleaner in DEBUG mode thanks to caching.

Assisted-by: gemini-3-flash <noreply@google.com>