### PR TITLE
[FIX] odoobin: improve debugger detection and fix filtering logic

### DIFF
--- a/odev/common/odoobin.py
+++ b/odev/common/odoobin.py
@@ -895,7 +895,8 @@ class OdoobinProcess(OdevFrameworkMixin):
         addons_paths.add(odoo_base_path)
 
         for addon in addons_paths:
-            yield from find_debuggers(addon)
+            if addon.is_dir():
+                yield from find_debuggers(addon)
 
     def save_database_repository(self):
         """Link the database to the first repository in additional addons-paths, allowing for reusing it in subsequent

--- a/odev/common/odoobin.py
+++ b/odev/common/odoobin.py
@@ -626,7 +626,7 @@ class OdoobinProcess(OdevFrameworkMixin):
                     self.database.worktree = self.worktree
 
                     internal_filter = self.get_stream_filter()
-                    if internal_filter:
+                    if internal_filter and stream_filter is not None:
                         original_filter = stream_filter
 
                         def combined_filter(line: str) -> str | None:
@@ -892,6 +892,7 @@ class OdoobinProcess(OdevFrameworkMixin):
         """
         odoo_base_path: Path = self.odoo_path / "odoo"
         addons_paths = {(odoo_base_path if odoo_base_path in path.parents else path) for path in self.addons_paths}
+        addons_paths.add(odoo_base_path)
 
         for addon in addons_paths:
             yield from find_debuggers(addon)


### PR DESCRIPTION
This PR fixes issues with ipdb/pdb not working in odev by:
1. Including the core odoo package in debugger detection.
2. Ensuring sandbox log filtering doesn't re-enable streaming when a debugger is detected.