### PR TITLE
[FIX] store.secrets: close the ssh-agent connection after (de)ciphering

### DIFF
--- a/odev/common/store/tables/secrets.py
+++ b/odev/common/store/tables/secrets.py
@@ -1,6 +1,7 @@
 import os
 from base64 import b64decode, b64encode
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Literal
 
@@ -68,22 +69,28 @@ class SecretStore(PostgresTable):
     """Configuration parameters."""
 
     @classmethod
-    def _list_ssh_keys(cls) -> list[AgentKey]:
-        """List all SSH keys available in the ssh-agent."""
-        keys = list(SSHAgent().get_keys())
+    @contextmanager
+    def _ssh_keys(cls) -> Iterator[list[AgentKey]]:
+        """Yield SSH keys and close the agent connection on exit."""
+        agent = SSHAgent()
 
-        if not keys and not os.environ.get("ODEV_NO_SSH_AGENT"):
-            raise OdevError("No SSH keys found in ssh-agent, or ssh-agent is not running.")
+        try:
+            keys = list(agent.get_keys())
 
-        fingerprint = cls.config.security.encryption_key
+            if not keys and not os.environ.get("ODEV_NO_SSH_AGENT"):
+                raise OdevError("No SSH keys found in ssh-agent, or ssh-agent is not running.")
 
-        if fingerprint:
-            for i, key in enumerate(keys):
-                if key.fingerprint == fingerprint:
-                    keys.insert(0, keys.pop(i))
-                    break
+            fingerprint = cls.config.security.encryption_key
 
-        return keys
+            if fingerprint:
+                for i, key in enumerate(keys):
+                    if key.fingerprint == fingerprint:
+                        keys.insert(0, keys.pop(i))
+                        break
+
+            yield keys
+        finally:
+            agent.close()
 
     @classmethod
     def encrypt(cls, plaintext: str) -> str:
@@ -94,19 +101,19 @@ class SecretStore(PostgresTable):
         :rtype: str
         """
         ciphered: str | None = None
-        keys = cls._list_ssh_keys()
 
-        if not keys:
-            return plaintext
+        with cls._ssh_keys() as keys:
+            if not keys:
+                return plaintext
 
-        for key in keys:
-            try:
-                ciphered = str(b64encode(ssh_encrypt(plaintext, ssh_key=key)).decode()) if plaintext else ""
-            except SSHException as e:
-                logger.debug(f"Failed to encrypt with key {key.fingerprint} ({key.name}, {key.comment}): {e}")
-            else:
-                cls.config.security.encryption_key = key.fingerprint
-                break
+            for key in keys:
+                try:
+                    ciphered = str(b64encode(ssh_encrypt(plaintext, ssh_key=key)).decode()) if plaintext else ""
+                except SSHException as e:
+                    logger.debug(f"Failed to encrypt with key {key.fingerprint} ({key.name}, {key.comment}): {e}")
+                else:
+                    cls.config.security.encryption_key = key.fingerprint
+                    break
 
         if ciphered is None:
             raise OdevError("Encryption failed, no key could be used for signing.")
@@ -122,27 +129,27 @@ class SecretStore(PostgresTable):
         :rtype: str
         """
         deciphered: str | None = None
-        keys = cls._list_ssh_keys()
 
-        if not keys:
-            return ciphertext
+        with cls._ssh_keys() as keys:
+            if not keys:
+                return ciphertext
 
-        for key in keys:
-            key_desc = f"{key.fingerprint} ({key.name}, {key.comment})"
+            for key in keys:
+                key_desc = f"{key.fingerprint} ({key.name}, {key.comment})"
 
-            try:
-                deciphered = (
-                    str(ssh_decrypt(b64decode(ciphertext.encode()).decode(), ssh_key=key)) if ciphertext else ""
-                )
-            except SSHException as e:
-                logger.debug(f"Failed to decrypt with key {key_desc}: {e}")
-            except UnicodeDecodeError as e:
-                logger.debug(f"Failed to decode decrypted string with key {key_desc}: {e}")
-            except ValueError as e:
-                logger.debug(f"Unexpected error when trying to handle SSH key {key_desc}: {e}")
-            else:
-                cls.config.security.encryption_key = key.fingerprint
-                break
+                try:
+                    deciphered = (
+                        str(ssh_decrypt(b64decode(ciphertext.encode()).decode(), ssh_key=key)) if ciphertext else ""
+                    )
+                except SSHException as e:
+                    logger.debug(f"Failed to decrypt with key {key_desc}: {e}")
+                except UnicodeDecodeError as e:
+                    logger.debug(f"Failed to decode decrypted string with key {key_desc}: {e}")
+                except ValueError as e:
+                    logger.debug(f"Unexpected error when trying to handle SSH key {key_desc}: {e}")
+                else:
+                    cls.config.security.encryption_key = key.fingerprint
+                    break
 
         if deciphered is None:
             raise OdevError("Decryption failed, no key could be used")

--- a/tests/tests/common/test_secrets.py
+++ b/tests/tests/common/test_secrets.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock, patch
+
+from odev.common.errors import OdevError
+from odev.common.store.tables.secrets import SecretStore
+
+from tests.fixtures import OdevTestCase
+
+
+class TestSecretStore(OdevTestCase):
+    """Tests for the (de)ciphering of secrets through the ssh-agent."""
+
+    def setUp(self):
+        super().setUp()
+        self.mock_key = MagicMock()
+        self.mock_key.name = "ssh-rsa"
+        self.mock_key.fingerprint = "SHA256:test"
+        self.mock_key.comment = "test key"
+        self.mock_key.sign_ssh_data.side_effect = lambda data: b"signed-" + data
+
+        self.mock_agent = MagicMock()
+        self.mock_agent.get_keys.return_value = (self.mock_key,)
+
+        for patcher in (
+            patch("odev.common.store.tables.secrets.SSHAgent", return_value=self.mock_agent),
+            patch.object(SecretStore, "config", self.odev.config),
+            patch.dict("os.environ", {"ODEV_NO_SSH_AGENT": ""}),
+        ):
+            self.addCleanup(patcher.stop)
+            patcher.start()
+
+    def test_encrypt_closes_the_ssh_agent(self):
+        SecretStore.encrypt("password")
+        self.mock_agent.close.assert_called_once()
+
+    def test_decrypt_closes_the_ssh_agent(self):
+        ciphertext = SecretStore.encrypt("password")
+        self.mock_agent.close.reset_mock()
+
+        self.assertEqual(SecretStore.decrypt(ciphertext), "password")
+        self.mock_agent.close.assert_called_once()
+
+    def test_ssh_agent_closed_on_error(self):
+        self.mock_agent.get_keys.return_value = ()
+
+        with self.assertRaises(OdevError):
+            SecretStore.encrypt("password")
+
+        self.mock_agent.close.assert_called_once()
+
+    def test_keys_are_usable_while_the_agent_is_open(self):
+        calls: list[str] = []
+        self.mock_key.sign_ssh_data.side_effect = lambda data: calls.append("sign") or b"signed-" + data
+        self.mock_agent.close.side_effect = lambda: calls.append("close")
+
+        SecretStore.encrypt("password")
+
+        self.assertIn("sign", calls)
+        self.assertEqual(calls[-1], "close")
+
+    def test_preferred_key_is_tried_first(self):
+        other_key = MagicMock()
+        other_key.name = "ssh-rsa"
+        other_key.fingerprint = "SHA256:other"
+        other_key.comment = "other key"
+        other_key.sign_ssh_data.side_effect = lambda data: b"other-" + data
+        self.mock_agent.get_keys.return_value = (other_key, self.mock_key)
+        SecretStore.config.security.encryption_key = self.mock_key.fingerprint
+
+        SecretStore.encrypt("password")
+
+        self.mock_key.sign_ssh_data.assert_called()
+        other_key.sign_ssh_data.assert_not_called()


### PR DESCRIPTION
## Description
`SecretStore` listed the agent keys through `list(SSHAgent().get_keys())` and never closed the agent. `paramiko.agent.Agent` opens a socket to `SSH_AUTH_SOCK` on instantiation, has no finalizer, and holds a reference cycle with the keys it returns, so refcounting never reclaims it and the file descriptor stays open until the cycle collector happens to run: 200 calls grew the process from 6 to 206 open descriptors. Every authenticated request reads its session cookie from the vault and saves the cookies back once it completes, so a command polling a backend in a loop exhausted the process file descriptors and failed with `[Errno 24] Too many open files`.

Replace `_list_ssh_keys` with a `_ssh_keys` context manager that keeps the agent open while the keys are in use, as they sign through the agent socket and closing it before `ssh_crypt` runs would break (de)ciphering, and closes it in a `finally` block, including when no usable key is found.

## Compliance

- [x] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [x] I have added or modified unit tests where necessary
- [x] I have added new libraries to the `requirements.txt` file, if any
- [x] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
